### PR TITLE
Removes the dependency of sagemaker-training

### DIFF
--- a/plugins/flytekit-aws-sagemakerprocessing/requirements.txt
+++ b/plugins/flytekit-aws-sagemakerprocessing/requirements.txt
@@ -10,14 +10,10 @@ arrow==1.2.2
     # via jinja2-time
 attrs==21.4.0
     # via sagemaker
-bcrypt==4.0.0
-    # via paramiko
 binaryornot==0.4.4
     # via cookiecutter
 boto3==1.24.60
-    # via
-    #   sagemaker
-    #   sagemaker-training
+    # via sagemaker
 botocore==1.27.60
     # via
     #   boto3
@@ -25,9 +21,7 @@ botocore==1.27.60
 certifi==2022.6.15
     # via requests
 cffi==1.15.1
-    # via
-    #   cryptography
-    #   pynacl
+    # via cryptography
 chardet==5.0.0
     # via binaryornot
 charset-normalizer==2.1.1
@@ -43,9 +37,7 @@ cookiecutter==2.1.1
 croniter==1.3.5
     # via flytekit
 cryptography==37.0.4
-    # via
-    #   paramiko
-    #   pyopenssl
+    # via pyopenssl
 dataclasses-json==0.5.7
     # via flytekit
 decorator==5.1.1
@@ -68,16 +60,12 @@ flyteidl==1.1.12
     # via flytekit
 flytekit==1.1.1
     # via flytekitplugins-sagemakerprocessing
-gevent==21.12.0
-    # via sagemaker-training
 google-pasta==0.2.0
     # via sagemaker
 googleapis-common-protos==1.56.4
     # via
     #   flyteidl
     #   grpcio-status
-greenlet==1.1.3
-    # via gevent
 grpcio==1.47.0
     # via
     #   flytekit
@@ -90,8 +78,6 @@ importlib-metadata==4.12.0
     # via
     #   flytekit
     #   sagemaker
-inotify-simple==1.2.1
-    # via sagemaker-training
 jinja2==3.1.2
     # via
     #   cookiecutter
@@ -105,9 +91,7 @@ jmespath==1.0.1
 keyring==23.8.2
     # via flytekit
 markupsafe==2.1.1
-    # via
-    #   jinja2
-    #   werkzeug
+    # via jinja2
 marshmallow==3.17.1
     # via
     #   dataclasses-json
@@ -128,8 +112,6 @@ numpy==1.23.2
     #   pandas
     #   pyarrow
     #   sagemaker
-    #   sagemaker-training
-    #   scipy
 packaging==21.3
     # via
     #   marshmallow
@@ -138,8 +120,6 @@ pandas==1.4.3
     # via
     #   flytekit
     #   sagemaker
-paramiko==2.11.0
-    # via sagemaker-training
 pathos==0.2.9
     # via sagemaker
 pox==0.3.1
@@ -155,21 +135,16 @@ protobuf==3.20.1
     #   protobuf3-to-dict
     #   protoc-gen-swagger
     #   sagemaker
-    #   sagemaker-training
 protobuf3-to-dict==0.1.5
     # via sagemaker
 protoc-gen-swagger==0.1.0
     # via flyteidl
-psutil==5.9.1
-    # via sagemaker-training
 py==1.11.0
     # via retry
 pyarrow==6.0.1
     # via flytekit
 pycparser==2.21
     # via cffi
-pynacl==1.5.0
-    # via paramiko
 pyopenssl==22.0.0
     # via flytekit
 pyparsing==3.0.9
@@ -207,26 +182,17 @@ responses==0.21.0
     # via flytekit
 retry==0.9.2
     # via flytekit
-retrying==1.3.3
-    # via sagemaker-training
 s3transfer==0.6.0
     # via boto3
 sagemaker==2.106.0
     # via flytekitplugins-sagemakerprocessing
-sagemaker-training==3.9.2
-    # via flytekitplugins-sagemakerprocessing
-scipy==1.9.0
-    # via sagemaker-training
 six==1.16.0
     # via
     #   google-pasta
     #   grpcio
-    #   paramiko
     #   ppft
     #   protobuf3-to-dict
     #   python-dateutil
-    #   retrying
-    #   sagemaker-training
 smdebug-rulesconfig==1.0.1
     # via sagemaker
 sortedcontainers==2.4.0
@@ -249,8 +215,6 @@ urllib3==1.26.12
     #   responses
 websocket-client==1.4.0
     # via docker
-werkzeug==2.2.2
-    # via sagemaker-training
 wheel==0.37.1
     # via flytekit
 wrapt==1.14.1
@@ -259,11 +223,3 @@ wrapt==1.14.1
     #   flytekit
 zipp==3.8.1
     # via importlib-metadata
-zope-event==4.5.0
-    # via gevent
-zope-interface==5.4.0
-    # via gevent
-
-# The following packages are considered to be unsafe in a requirements file:
-# pip
-# setuptools

--- a/plugins/flytekit-aws-sagemakerprocessing/setup.py
+++ b/plugins/flytekit-aws-sagemakerprocessing/setup.py
@@ -4,7 +4,7 @@ PLUGIN_NAME = "sagemakerprocessing"
 
 microlib_name = f"flytekitplugins-{PLUGIN_NAME}"
 
-plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "sagemaker-training>=3.6.2,<4.0.0", "sagemaker>=2.106.0"]
+plugin_requires = ["flytekit>=1.1.0b0,<1.2.0", "sagemaker>=2.106.0"]
 
 __version__ = "0.0.0+develop"
 


### PR DESCRIPTION
# TL;DR
_Removes the dependency of sagemaker-training._

Which results in workflows using the `flytekit-aws-sagemakerprocessing` package not require 'gcc' in the docker container

## Type
 - [X ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

